### PR TITLE
Fix prod StagingInterceptor load error (DP-606)

### DIFF
--- a/app/mailers/interceptors/staging_interceptor.rb
+++ b/app/mailers/interceptors/staging_interceptor.rb
@@ -2,17 +2,19 @@
 #
 # The original To/CC/BCC are stored in X-Original-### headers, which you can
 # inspect when doing QA on the staging site.
-class StagingInterceptor
-  def self.delivering_email(mail)
-    # Use headers to indicate who we would have emailed. Note that we don't add
-    # this to the body so as not to mess up HTML/Text content.
-    mail.header['X-LAP-Service'] = 'geodata'
-    mail.header['X-Original-To'] = mail.to
-    mail.header['X-Original-CC'] = mail.cc
-    mail.header['X-Original-BCC'] = mail.bcc
+module Interceptors
+  class StagingInterceptor
+    def self.delivering_email(mail)
+      # Use headers to indicate who we would have emailed. Note that we don't add
+      # this to the body so as not to mess up HTML/Text content.
+      mail.header['X-LAP-Service'] = 'geodata'
+      mail.header['X-Original-To'] = mail.to
+      mail.header['X-Original-CC'] = mail.cc
+      mail.header['X-Original-BCC'] = mail.bcc
 
-    # Forward solely to the test list
-    mail.to = 'lib-testmail@lists.berkeley.edu'
-    mail.cc = mail.bcc = ''
+      # Forward solely to the test list
+      mail.to = 'lib-testmail@lists.berkeley.edu'
+      mail.cc = mail.bcc = ''
+    end
   end
 end


### PR DESCRIPTION
The new Rails autoloader expects the file to be namespaced within a module. Verify this by running the following with and without this commit present:

```sh
docker-compose run --rm \
    -e RAILS_ENV=production \
    -e SECRET_KEY_BASE=1234 \
    app rails s
```

This succeeds with this commit, but fails without it with an error like:

> Unknown const in StagingInterceptor (NameError)