### PR TITLE
Fix interceptor loading in production (DP-606)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     omniauth (1.9.2)
@@ -460,6 +462,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
   x86_64-linux-musl
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  ActionMailer::Base.register_interceptor(StagingInterceptor) if ENV['INTERCEPT_EMAILS'].present?
+  ActionMailer::Base.register_interceptor(Interceptors::StagingInterceptor) if ENV['INTERCEPT_EMAILS'].present?
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   solr:
-    image: solr:${SOLR_VERSION}
+    image: solr:${SOLR_VERSION:-8.11.1}
     restart: always
     ports:
       - 8983:8983


### PR DESCRIPTION
… For real, this time! The correct test would've been to enable the interceptor:

```sh
docker compose run --rm \
    -e INTERCEPT_EMAILS=true \
    -e RAILS_ENV=production \
    -e SECRET_KEY_BASE=1 \
    app rails s
```