### PR TITLE
Ada 232

### DIFF
--- a/app/assets/stylesheets/_customizations.scss
+++ b/app/assets/stylesheets/_customizations.scss
@@ -17,3 +17,9 @@
   background-color: #0073EB;
   color: #ffffff;
 }
+
+span.facet-label {
+  span.selected {
+    color: #208836 !important;
+  }
+}

--- a/app/assets/stylesheets/_customizations.scss
+++ b/app/assets/stylesheets/_customizations.scss
@@ -12,14 +12,35 @@
   height: 6em;
 }
 
-// Fixing: AAD-232 
 .btn-primary {
-  background-color: #0073EB;
+  background-color: $link-color;
   color: #ffffff;
 }
 
 span.facet-label {
   span.selected {
     color: #208836 !important;
+  }
+}
+
+.nav-pills .nav-link.active,
+.nav-pills .show>.nav-link,
+.nav-pills .no-js .btn-group:focus-within .dropdown-menu>.nav-link,
+.nav-pills .no-js .btn-group:focus-within .twitter-typeahead .tt-menu>.nav-link,
+.twitter-typeahead .nav-pills .no-js .btn-group:focus-within .tt-menu>.nav-link,
+.no-js .btn-group:focus-within .nav-pills .dropdown-menu>.nav-link,
+.no-js .btn-group:focus-within .nav-pills .twitter-typeahead .tt-menu>.nav-link,
+.twitter-typeahead .no-js .btn-group:focus-within .nav-pills .tt-menu>.nav-link {
+  background-color: $link-color;
+}
+
+#metadata-container {
+  a {
+    color: #006FD6;
+
+    &:hover {
+      color: #0044B3;
+      text-decoration: underline;
+    }
   }
 }

--- a/app/assets/stylesheets/_customizations.scss
+++ b/app/assets/stylesheets/_customizations.scss
@@ -1,7 +1,6 @@
-
-.ucb_container{
+.ucb_container {
   min-height: 100%;
-  width: 100%;  
+  width: 100%;
   margin-bottom: 90px;
 }
 
@@ -9,6 +8,12 @@
   height: 90px;
 }
 
-.navbar {  
-  height: 6em;  
+.navbar {
+  height: 6em;
+}
+
+// Fixing: AAD-232 
+.btn-primary {
+  background-color: #0073EB;
+  color: #ffffff;
 }

--- a/app/assets/stylesheets/_customizations.scss
+++ b/app/assets/stylesheets/_customizations.scss
@@ -17,7 +17,7 @@
   color: #ffffff;
 }
 
-span.facet-label {
+ul.facet-values {
   span.selected {
     color: #208836 !important;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,3 @@
-// Fixing: AAD-232 
 $link-color: #0073EB;
 @import 'bootstrap';
 @import 'blacklight';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$link-color: #0073EB;
+$link-hover-color: #003366;
 @import 'bootstrap';
 @import 'blacklight';
 @import 'geoblacklight';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
+// Fixing: AAD-232 
 $link-color: #0073EB;
-$link-hover-color: #003366;
 @import 'bootstrap';
 @import 'blacklight';
 @import 'geoblacklight';


### PR DESCRIPTION

In addition to the  link elements, the Axe tool also flagged other elements for insufficient color contrast. These issues have also been resolved.

1.
<span class="submit-search-text">Search</span>
Element has insufficient color contrast of 3.97 (foreground color: #ffffff, background color: #007bff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1

2. <span class="selected">
Element has insufficient color contrast of 3.13 (foreground color: #28a745, background color: #ffffff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1

3. Elements from the metadata modal:
<a class="pill-metadata nav-link active" href="#iso19139" aria-controls="iso19139" role="tab" data-toggle="pill" data-ref-endpoint="https://spatial.lib.berkeley.edu/metadata/berkeley-s7038h/iso19139.xml" data-ref-download="#btn-metadata-download">ISO 19139</a>
Element has insufficient color contrast of 3.97 (foreground color: #ffffff, background color: #007bff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1

4.Elements from the metadata modal:
<a href="#iso-spatial-reference-info">Spatial Reference Information</a>
Element has insufficient color contrast of 4.14 (foreground color: #0073eb, background color: #f5f5f5, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1


