### PR TITLE
AP-730 ensure geodata pushes multi-arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,126 +3,35 @@ name: Build / Test / Push
 on:
   push:
     branches:
-      - '**'
+      - "**"
+  workflow_call:
   workflow_dispatch:
 
 env:
   BUILD_SUFFIX: -build-${{ github.run_id }}_${{ github.run_attempt }}
-  DOCKER_METADATA_SET_OUTPUT_ENV: 'true'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.runner }}
-    outputs:
-      image-arm64: ${{ steps.gen-output.outputs.image-arm64 }}
-      image-x64: ${{ steps.gen-output.outputs.image-x64 }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: build-meta
-        name: Docker meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: type=sha,suffix=${{ env.BUILD_SUFFIX }}
-
-      # Build cache is shared among all builds of the same architecture
-      - id: cache-meta
-        name: Docker meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: type=raw,value=buildcache-${{ runner.arch }}
-
-      - id: get-registry
-        name: Get the sanitized registry name
-        run: |
-          echo "registry=$(echo '${{ steps.build-meta.outputs.tags }}' | cut -f1 -d:)" | tee -a "$GITHUB_OUTPUT"
-
-      - id: build
-        name: Build/push the arch-specific image
-        uses: docker/build-push-action@v6
-        with:
-          cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
-          cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max
-          labels: ${{ steps.build-meta.outputs.labels }}
-          provenance: mode=max
-          sbom: true
-          tags: ${{ steps.get-registry.outputs.registry }}
-          outputs: type=image,push-by-digest=true,push=true
-
-      - id: gen-output
-        name: Write arch-specific image digest to outputs
-        run: |
-          echo "image-${RUNNER_ARCH,,}=${{ steps.get-registry.outputs.registry }}@${{ steps.build.outputs.digest }}" | tee -a "$GITHUB_OUTPUT"
-
-  merge:
-    runs-on: ubuntu-24.04
-    needs: build
-    env:
-      DOCKER_APP_IMAGE_ARM64: ${{ needs.build.outputs.image-arm64 }}
-      DOCKER_APP_IMAGE_X64: ${{ needs.build.outputs.image-x64 }}
-    outputs:
-      image: ${{ steps.meta.outputs.tags }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: meta
-        name: Generate tag for the app image
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: type=sha,suffix=${{ env.BUILD_SUFFIX }}
-
-      - name: Push the multi-platform app image
-        run: |
-          docker buildx imagetools create \
-            --tag "$DOCKER_METADATA_OUTPUT_TAGS" \
-            "$DOCKER_APP_IMAGE_ARM64" "$DOCKER_APP_IMAGE_X64"
+  docker-build:
+    uses: BerkeleyLibrary/.github/.github/workflows/docker-build.yml@v2.0.0
+    with:
+      image: ghcr.io/${{ github.repository }}
+    secrets: inherit
 
   test:
     runs-on: ubuntu-24.04
-    needs: merge
+    needs: docker-build
     env:
       COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
-      DOCKER_APP_IMAGE: ${{ needs.merge.outputs.image }}
+      DOCKER_APP_IMAGE: ${{ needs.docker-build.outputs.image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
+        uses: docker/setup-compose-action@v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -130,8 +39,6 @@ jobs:
 
       - name: Setup the stack
         run: |
-          docker compose build --quiet
-          docker compose pull --quiet
           docker compose up --wait
           docker compose exec app rails assets:precompile db:prepare geoblacklight:index:seed
           docker compose exec -e RAILS_ENV=test app rails db:prepare geoblacklight:index:seed
@@ -156,41 +63,19 @@ jobs:
 
       - name: Upload the test report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: GeoData Build Report (${{ github.run_id }}_${{ github.run_attempt }})
           path: artifacts/*
           if-no-files-found: error
 
   push:
-    runs-on: ubuntu-24.04
     needs:
-      - merge
+      - docker-build
       - test
-    env:
-      DOCKER_APP_IMAGE: ${{ needs.merge.outputs.image }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Produce permanent image tags
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=sha
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Retag and push the image
-        run: |
-          docker pull "$DOCKER_APP_IMAGE"
-          echo "$DOCKER_METADATA_OUTPUT_TAGS" | tr ' ' '\n' | xargs -n1 docker tag "$DOCKER_APP_IMAGE"
-          docker push --all-tags "$(echo "$DOCKER_APP_IMAGE" | cut -f1 -d:)"
+    uses: BerkeleyLibrary/.github/.github/workflows/docker-push.yml@v2.0.0
+    with:
+      image: ghcr.io/${{ github.repository }}
+      build-image-arm64: ${{ needs.docker-build.outputs.image-arm64 }}
+      build-image-x64: ${{ needs.docker-build.outputs.image-x64 }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,57 +3,12 @@ name: Push Release Tags
 on:
   push:
     tags:
-      - '**'
+      - "**"
+  workflow_call:
   workflow_dispatch:
-
-env:
-  DOCKER_METADATA_SET_OUTPUT_ENV: 'true'
-
 jobs:
-  retag:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Determine the sha-based image tag to retag
-        id: get-base-image
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: type=sha
-
-      - name: Verify that the image was previously built
-        env:
-          BASE_IMAGE: ${{ steps.get-base-image.outputs.tags }}
-        run: |
-          docker pull "$BASE_IMAGE"
-
-      - name: Produce release tags
-        id: tag-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          flavor: latest=false
-          tags: |
-            type=ref,event=tag
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
-
-      - name: Retag the pulled image
-        env:
-          BASE_IMAGE: ${{ steps.get-base-image.outputs.tags }}
-        run: |
-          echo "$DOCKER_METADATA_OUTPUT_TAGS" | tr ' ' '\n' | xargs -n1 docker tag "$BASE_IMAGE"
-          docker push --all-tags "$(echo "$BASE_IMAGE" | cut -f1 -d:)"
+  release:
+    uses: BerkeleyLibrary/.github/.github/workflows/docker-release.yml@v2.0.0
+    with:
+      image: ghcr.io/${{ github.repository }}
+    secrets: inherit


### PR DESCRIPTION
 - Updates build and release action workflows to use org's .github/.github workflow templates.
 - replaces build, merge, push, and release jobs
 - slightly updates test job to not rebuild/pull image