### PR TITLE
AP-748 Configure the App

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -294,10 +294,10 @@ class CatalogController < ApplicationController
     # Tools from Blacklight
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
-    config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    # config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:citation)
-    config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
-    config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
+    # config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
+    # config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,9 +102,9 @@ USE_GEOM_FOR_RELATIONS_ICON: false
 
 # Web services shown in tool panel
 WEBSERVICES_SHOWN:
-  - 'wms'
+  # - 'wms'
   - 'tms'
-  - 'wfs'
+  # - 'wfs'
   - 'xyz'
   - 'wmts'
   - 'tilejson'


### PR DESCRIPTION
We need to remove some tools and a tab from map viewer (see below)

Remove below tools :
 - Bookmarks
 - Email
 - SMS This

Remove tab: Web services (*)
If I'm understanding @yzhoubk, it's not that we're removing the "Web Services" button, but actually just removing two of the types of web services from the list that triggers the button to show. We're removing 'wms' and 'wfs' types.

<img width="1539" height="891" alt="image" src="https://github.com/user-attachments/assets/ebf4efa8-9466-4c58-9b87-b87d8376510b" />
