### PR TITLE
AP-799-2: Include yarn css build in initial Docker container setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ WORKDIR /opt/app
 # Add binstubs to the path.
 ENV PATH="/opt/app/bin:$PATH"
 
+ENTRYPOINT ["bin/docker-entrypoint.sh"]
+
 # If run with no other arguments, the image will start the rails server by
 # default. Note that we must bind to all interfaces (0.0.0.0) because when
 # running in a docker container, the actual public interface is created

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -12,5 +12,10 @@ echo 'what server is shutdown !!!'
 unset BUNDLE_PATH
 unset BUNDLE_BIN
 
+if [ ! -f /opt/app/app/assets/builds/application.css ]; then
+	echo 'application.css missing, building CSS assets'
+	yarn build:css
+fi
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"

--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,12 @@ def system!(*args)
 end
 
 FileUtils.chdir APP_ROOT do
+  puts "\n== Installing JavaScript dependencies =="
+  system! "yarn install"
+
+  puts "\n== Building CSS =="
+  system! "yarn build:css"
+
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare RAILS_ENV=test"
   system! "bin/rails db:prepare"


### PR DESCRIPTION
- Yarn build:css through docker-entrypoint.sh
- Add Yarn build:css in setup